### PR TITLE
Remove dependency on laravel framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   ],
   "require": {
     "php": "^7.2",
-    "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
+    "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+    "illuminate/database": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
   },
   "require-dev": {
     "orchestra/testbench": "~3.4|^4.0",


### PR DESCRIPTION
Only use referenced illuminate libraries instead of entire laravel framework. Allows code to be used with lumen